### PR TITLE
Add `numpy~=1.17.5` dependency explicitly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+numpy~=1.17.5
 optimade-client~=2020.9.16.dev2


### PR DESCRIPTION
This is to satisfy the older numpy dependency of aiida-core.

Closes #2 