### PR TITLE
Deprecate OptimadeQueryWidget

### DIFF
--- a/aiidalab_optimade/widget.py
+++ b/aiidalab_optimade/widget.py
@@ -1,41 +1,14 @@
-import traitlets
-import ipywidgets as ipw
-
 try:
-    from aiida.orm import StructureData
+    from aiidalab_widgets_base.structures import OptimadeQueryWidget
 except ImportError:
-    StructureData = object
+    OptimadeQueryWidget = object
 
-from optimade_client.query_filter import OptimadeQueryFilterWidget
-from optimade_client.query_provider import OptimadeQueryProviderWidget
+import warnings
 
-
-class OptimadeQueryWidget(ipw.VBox):
-    """Combined widget for OptimadeQuery*Widget"""
-
-    structure = traitlets.Instance(StructureData, allow_none=True)
-
-    def __init__(self, embedded: bool = True, **kwargs):
-        providers = OptimadeQueryProviderWidget(embedded=embedded)
-        filters = OptimadeQueryFilterWidget()
-
-        ipw.dlink((providers, "database"), (filters, "database"))
-
-        filters.observe(self.update_structure, names="structure")
-
-        super().__init__(
-            children=(providers, filters), layout={"width": "auto", "height": "auto"}
-        )
-
-    def update_structure(self, change: dict):
-        """New structure chosen"""
-        new_structure = change["new"]
-        if new_structure is None:
-            self.structure = None
-        else:
-            try:
-                self.structure = new_structure.as_aiida_structuredata
-            except AttributeError:
-                raise
-            except Exception:  # pylint: disable=broad-except
-                self.structure = None
+warnings.warn(
+    (
+        "Importing OptimadeQueryWidget from `aiidalab_optimade` has been deprecated, "
+        "instead import it from `aiidalab_widgets_base.structures`."
+    ),
+    DeprecationWarning
+)

--- a/aiidalab_optimade/widget.py
+++ b/aiidalab_optimade/widget.py
@@ -1,5 +1,5 @@
 try:
-    from aiidalab_widgets_base.structures import OptimadeQueryWidget
+    from aiidalab_widgets_base.databases import OptimadeQueryWidget
 except ImportError:
     OptimadeQueryWidget = object
 
@@ -8,7 +8,7 @@ import warnings
 warnings.warn(
     (
         "Importing OptimadeQueryWidget from `aiidalab_optimade` has been deprecated, "
-        "instead import it from `aiidalab_widgets_base.structures`."
+        "instead import it from `aiidalab_widgets_base`."
     ),
-    DeprecationWarning
+    DeprecationWarning,
 )


### PR DESCRIPTION
Closes #4.

It has moved to aiidalab-widgets-base.

**NOTE**: Should _not_ be merged until aiidalab/aiidalab-widgets-base#131 has been merged.