### PR TITLE
Show warning message in Jupyter notebooks

### DIFF
--- a/aiidalab_optimade/widget.py
+++ b/aiidalab_optimade/widget.py
@@ -1,9 +1,11 @@
+import warnings
+
 try:
     from aiidalab_widgets_base.databases import OptimadeQueryWidget
 except ImportError:
     OptimadeQueryWidget = object
 
-import warnings
+warnings.filterwarnings(action='once')
 
 warnings.warn(
     (


### PR DESCRIPTION
For unknown reason the previous implementation wouldn't
show a deprecation warning in Jupyter. The change introduced
here makes the warning to appear once in the same notebook.

N.B. in the appmode the warning is not shown.